### PR TITLE
Ensure Markdown dependency is installed

### DIFF
--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -1,5 +1,12 @@
 import os
 
+try:
+    import markdown  # noqa: F401
+except ImportError as exc:  # pragma: no cover
+    raise RuntimeError(
+        "The 'markdown' package is required to build the site"
+    ) from exc
+
 # Theme-specific settings
 SITENAME = "Marc Sleegers"
 DOMAIN = "marcsleegers.com"


### PR DESCRIPTION
## Summary
- fail fast if `markdown` is missing by checking in `pelicanconf.py`

## Testing
- `flake8`
- `pelican content -s pelicanconf.py -o output_tmp -v`

------
https://chatgpt.com/codex/tasks/task_e_6842f32a13d4832b9b55382154219280