### PR TITLE
Add build verification workflow

### DIFF
--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -1,0 +1,23 @@
+name: 💻 Build Verification
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      - name: Set up Poetry
+        uses: abatilo/actions-poetry@v3.0.0
+        with:
+          poetry-version: 1.3.2
+      - name: Install dependencies
+        run: poetry install --no-root
+      - name: Verify build
+        run: poetry run pelican content -s publishconf.py


### PR DESCRIPTION
## Summary
- add GitHub Actions job to verify Pelican build on pull requests

## Testing
- `poetry install --no-root`
- `poetry run pelican content -s publishconf.py`

------
https://chatgpt.com/codex/tasks/task_e_6842f8188098832b8b92824bd8b3d01c