### PR TITLE
Fix publish output validation in CI

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -38,10 +38,17 @@ jobs:
       - name: Build production output
         run: make build-prod
 
+      - name: Verify generated publish output
+        run: |
+          test -f output/publish/index.html
+
       - name: Check internal links
         uses: lycheeverse/lychee-action@v2
         with:
-          args: --offline --no-progress --max-retries 2 --timeout 20 output/publish
+          args: >-
+            --offline --no-progress --max-retries 2 --timeout 20
+            output/publish/**/*.html
+            output/publish/**/*.xml
 
       - name: Run SEO checks
         run: make seo-check


### PR DESCRIPTION
### Motivation
- The PR validation job was failing when link checks ran against the publish directory root and when the generated publish export was absent, which obscured the real failure cause.
- The workflow needs an explicit, early assertion that the production `output/publish` export exists after `make build-prod` so failures are clearer.

### Description
- Add a `Verify generated publish output` step that runs `test -f output/publish/index.html` immediately after `make build-prod`.
- Update the Lychee invocation to target generated artifacts by passing `output/publish/**/*.html` and `output/publish/**/*.xml` instead of the directory root.
- Keep the existing `make seo-check` step unchanged and run it after the link checks.

### Testing
- Ran `make sync` to install dependencies and it completed successfully.
- Ran `make build-prod` and verified the file check `test -f output/publish/index.html` succeeded.
- Ran `make seo-check` which reported `SEO checks passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2dc8caa48832bb0225cea1d65da67)