### PR TITLE
Update JET title to Principal Engineer

### DIFF
--- a/content/extra/humans.txt
+++ b/content/extra/humans.txt
@@ -1,6 +1,6 @@
 Hiya!
 
-I'm a Principal Software Engineer at Nike currently located in The Netherlands.
+I'm a Principal Engineer at JET currently located in The Netherlands.
 
 These are my infrequent ramblings.
 

--- a/content/pages/Home.md
+++ b/content/pages/Home.md
@@ -5,7 +5,7 @@ save_as: index.html
 Template: home
 Status: published
 
-I’m a Principal Software Engineer at [JET](https://www.justeattakeaway.com){:target="_blank" rel="noopener noreferrer"}, responsible for the Data Platform. I lead cross-functional delivery and build systems that turn complex data into actionable decisions. Previously, I was a Principal Software Engineer at [Nike](https://nike.com){:target="_blank" rel="noopener noreferrer"} and a Machine Learning Consultant at [Avanade](https://www.avanade.com){:target="_blank" rel="noopener noreferrer"}.
+I’m a Principal Engineer at [JET](https://www.justeattakeaway.com){:target="_blank" rel="noopener noreferrer"}, responsible for the Data Platform. I lead cross-functional delivery and build systems that turn complex data into actionable decisions. Previously, I was a Principal Software Engineer at [Nike](https://nike.com){:target="_blank" rel="noopener noreferrer"} and a Machine Learning Consultant at [Avanade](https://www.avanade.com){:target="_blank" rel="noopener noreferrer"}.
 
 Over the past decade, I’ve focused on making large systems easier to build, understand, and run. I enjoy mentoring engineers and engineering managers as they grow into larger roles.
 

--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -15,7 +15,7 @@ DOMAIN = "marcsleegers.com"
 FOOTER_TEXT = f'&copy; {datetime.now().year} Marc Sleegers. Licensed <a href="https://creativecommons.org/licenses/by/4.0/">CC BY 4.0</a>.'
 
 SITE_AUTHOR = "Marc Sleegers"
-SITE_AUTHOR_TITLE = "Principal Software Engineer"
+SITE_AUTHOR_TITLE = "Principal Engineer"
 ICONS_PATH = "images/icons"
 SOCIAL_IMAGE_FILENAME = "portrait.jpg"
 SOCIAL_IMAGE_ALT = "Portrait of Marc Sleegers"
@@ -35,7 +35,7 @@ SOCIAL_PROFILE_URLS = [
     "https://twitter.com/marcardioid",
     "https://github.com/marcardioid",
 ]
-INDEX_DESCRIPTION = "Principal Software Engineer at JET writing about architecture, engineering leadership, and data-intensive platforms."
+INDEX_DESCRIPTION = "Principal Engineer at JET writing about architecture, engineering leadership, and data-intensive platforms."
 
 NAVIGATION_ITEMS = [
     ("/", "home", "Home"),


### PR DESCRIPTION
Replaces #31, which was opened from a `claude/`-prefixed branch.

## What changed

Updates the current job title at JET from "Principal Software Engineer" to "Principal Engineer" everywhere it surfaces on the home page:

- `content/pages/Home.md` — the visible intro paragraph. The historical Nike title is left as "Principal Software Engineer" since that was the actual role there.
- `pelicanconf.py` — `INDEX_DESCRIPTION`, which feeds the home page's meta description plus the Twitter/OG cards and the site-wide JSON-LD `description`.
- `pelicanconf.py` — `SITE_AUTHOR_TITLE`, which is the `jobTitle` in the home page's `ProfilePage` structured data (used only in `themes/haru/templates/home.html`).

Also refreshes `content/extra/humans.txt`, which was separately stale — it still described the role as Principal Software Engineer at Nike, and now reads "Principal Engineer at JET".

## Why

The title at JET is Principal Engineer; the copy and metadata were out of date.

## Verification

- `make check` — production build succeeded (3 articles, 1 page) and `scripts/check_seo_output.py` reported "SEO checks passed".

No version bump: this is content/metadata copy, not a site capability or fix to how the site is built.

No deploy behavior changes, so `.github/workflows/deploy_to_pages.yml` is unaffected.

---
_Generated by [Claude Code](https://claude.ai/code/session_017sWDfqG3cVfykwzVTj3MX8)_